### PR TITLE
У блоков может не быть префиксов

### DIFF
--- a/jquery-bem.js
+++ b/jquery-bem.js
@@ -8,7 +8,7 @@
 (function($) {
 ///////////////////////////////////////////////////////////////////////////////
 
-var blockPrefixes = '(?:b\\-|l\\-)',
+var blockPrefixes = '(?:b\\-|l\\-)?',
     elemSeparator = '__',
     modSeparator = '_',
     whitespace = '[\\x20\\t\\r\\n\\f]',


### PR DESCRIPTION
 Привет. Долго не мог понять, почему у меня не работает твой плагин, потом обнаружил, что префиксы необходимы обязательно.
Это неудобно, потому что многие используют методологию БЭМ без префиксов и даже в Яндексе собираются от них отказаться.
